### PR TITLE
Fix evidence: use the posterior precision in the quadratic term

### DIFF
--- a/rfest/EvidenceOpt/_base.py
+++ b/rfest/EvidenceOpt/_base.py
@@ -207,6 +207,23 @@ class EmpiricalBayes:
 
         See eq(10) in Park & Pillow (2011).
 
+        NOTE: eq(10) as printed has `mu' Lambda mu` in the quadratic term, where
+        Lambda is the posterior COVARIANCE defined one equation earlier. The
+        Gaussian marginal needs the posterior PRECISION there, so `t2` below
+        deliberately does not match the printed equation. Do not "correct" it
+        back.
+
+        The term has two equivalent forms, which is what makes the slip easy:
+
+            (X'y/sigma^2)' Lambda (X'y/sigma^2)  ==  mu' Lambda^-1 mu
+
+        since mu = Lambda X'y/sigma^2. The left form -- with an un-inverted
+        Lambda -- is the one used by Sahani & Linden (2003) eq(4) and by both
+        reference implementations, pillowlab/fastASD (neglogev_ASDspectral.m)
+        and leaduncker/SimpleEvidenceOpt (fminconWrapper_simpleEvidenceOpt.m).
+        Substituting mu into it without inverting Lambda gives the printed
+        equation. tests/test_evidence.py pins this against the closed form.
+
         """
 
         sigma = params[0]
@@ -217,7 +234,8 @@ class EmpiricalBayes:
 
         t0 = jnp.log(jnp.abs(2 * jnp.pi * sigma**2)) * self.n_samples
         t1 = jnp.linalg.slogdet(C_prior @ C_post_inv)[1]
-        t2 = -m_post.T @ C_post @ m_post
+        # Equivalently, and more cheaply: -m_post.T @ self.XtY / sigma**2
+        t2 = -m_post.T @ C_post_inv @ m_post
         t3 = self.YtY / sigma**2
 
         return 0.5 * (t0 + t1 + t2 + t3)

--- a/rfest/EvidenceOpt/_fasd.py
+++ b/rfest/EvidenceOpt/_fasd.py
@@ -129,6 +129,12 @@ class fASD:
         """
 
         See eq(10) in Park & Pillow (2011).
+
+        NOTE: `t2` deliberately does not match eq(10) as printed, which has the
+        posterior covariance where the Gaussian marginal needs the posterior
+        precision. See EmpiricalBayes.negative_log_evidence for the derivation
+        and for why the printed form is easy to arrive at. Do not "correct" it
+        back.
         """
 
         sigma = params[0]
@@ -139,7 +145,8 @@ class fASD:
 
         t0 = np.log(np.abs(2 * np.pi * sigma**2)) * self.n_samples
         t1 = np.linalg.slogdet(C_prior @ C_post_inv)[1]
-        t2 = -m_post.T @ C_post @ m_post
+        # Equivalently, and more cheaply: -m_post.T @ self.ZtY / sigma**2
+        t2 = -m_post.T @ C_post_inv @ m_post
         t3 = self.YtY / sigma**2
 
         return 0.5 * (t0 + t1 + t2 + t3)

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -1,0 +1,55 @@
+import numpy as np
+
+from rfest import ASD, Ridge
+
+
+def _exact_negative_log_evidence(X, y, C, sigma):
+    """-log N(y; 0, sigma^2 I + X C X').
+
+    For the linear-Gaussian model this IS the evidence, in closed form. It is
+    derived here independently of `EmpiricalBayes`, so it is a ground truth for
+    `negative_log_evidence` rather than a restatement of it -- a consistency
+    check of that method against its own sufficient statistics cannot
+    distinguish the posterior covariance from its inverse in the quadratic term.
+    """
+    n = X.shape[0]
+    S = sigma ** 2 * np.eye(n) + X @ C @ X.T
+    # Cholesky rather than slogdet: |S| underflows to 0 for these sizes.
+    L = np.linalg.cholesky(S)
+    return 0.5 * (2 * np.sum(np.log(np.diag(L)))
+                  + y @ np.linalg.solve(S, y)
+                  + n * np.log(2 * np.pi))
+
+
+def _smooth_rf_data(n_features=12, n_samples=400, sigma=0.5, random_seed=2046):
+    rng = np.random.default_rng(random_seed)
+    lag = np.arange(n_features)
+    w_true = np.exp(-0.5 * (lag - n_features / 3.) ** 2 / 2. ** 2)
+    X = rng.normal(size=(n_samples, n_features))
+    y = X @ w_true + sigma * rng.normal(size=n_samples)
+    return X, y, sigma
+
+
+def _assert_matches_exact(model, params, X, y, sigma):
+    C = np.asarray(model.update_C_prior(np.asarray(params))[0])
+    got = float(model.negative_log_evidence(np.asarray(params)))
+    want = _exact_negative_log_evidence(X, y, C, sigma)
+    assert np.isclose(got, want, rtol=1e-5), (params, got, want)
+
+
+def test_asd_negative_log_evidence_matches_gaussian_marginal():
+    # The smoothness scale is held small enough that the prior covariance stays
+    # well conditioned. `priors.py` forms its inverse as `inv(C + 1e-7 I)`, an
+    # absolute jitter, so at larger scales the objective departs from the exact
+    # evidence for a reason unrelated to the term under test here.
+    X, y, sigma = _smooth_rf_data()
+    model = ASD(X, y, dims=[X.shape[1]])
+    for delta in [1., 1.5]:
+        _assert_matches_exact(model, [sigma, 1., delta], X, y, sigma)
+
+
+def test_ridge_negative_log_evidence_matches_gaussian_marginal():
+    X, y, sigma = _smooth_rf_data()
+    model = Ridge(X, y, dims=[X.shape[1]])
+    for theta in [0.5, 2.]:
+        _assert_matches_exact(model, [sigma, 1., theta], X, y, sigma)


### PR DESCRIPTION
Fixes the evidence defect reported in #31.

## The change

`negative_log_evidence` computes the quadratic term as `-m_post' C_post m_post`.
The Gaussian marginal likelihood needs the inverse posterior covariance there.
`C_post_inv` is already in scope, so this is one token in each of `_base.py` and
`_fasd.py`:

```diff
-        t2 = -m_post.T @ C_post @ m_post
+        t2 = -m_post.T @ C_post_inv @ m_post
```

It is not a constant offset, so it changes which hyperparameters get selected.
On a smooth 1D RF the exact evidence peaks at a smoothness scale matching the
true RF width, while the old expression is monotone increasing in that scale and
therefore prefers the largest value on offer. Affects everything deriving from
`EmpiricalBayes` (Ridge, ARD, ASD, ALD, fASD); `ARDFixedPoint` and
`RidgeFixedPoint` are separate code paths and are untouched.

## The docstrings

Both methods cite eq(10) of Park & Pillow (2011), and that is where the
expression comes from -- eq(10) as printed has the posterior covariance in this
term. The docstrings now record that, because otherwise the next person checking
this code against its cited source will change it straight back.

They also record why the slip is easy. The correct term has two equivalent
forms,

```
(X'y/sigma^2)' Lambda (X'y/sigma^2)  ==  mu' Lambda^-1 mu
```

and the left one, with an un-inverted `Lambda`, is what Sahani & Linden (2003)
eq(4) uses and what both reference implementations use --
[`pillowlab/fastASD`](https://github.com/pillowlab/fastASD/blob/master/code_fastASD/neglogev_ASDspectral.m)
(`neglogev_ASDspectral.m:67`) and
[`leaduncker/SimpleEvidenceOpt`](https://github.com/leaduncker/SimpleEvidenceOpt/blob/master/main/fminconWrapper_simpleEvidenceOpt.m)
(`fminconWrapper:20-22`). Substituting `mu` into that form without inverting
`Lambda` produces the printed equation.

## The test

`tests/test_evidence.py` compares `negative_log_evidence` against
`log N(y; 0, sigma^2 I + X C X')`, derived independently, for `ASD` and `Ridge`.

The external ground truth is the point. The old expression is smooth, finite and
differentiable and optimizes to a confident answer, so no check of the method
against its own sufficient statistics separates `C_post` from `C_post_inv`. The
new tests fail on the old expression (3364.4 against an exact 316.9) and pass on
this one.

The ASD test holds the smoothness scale small so the prior covariance stays well
conditioned: `priors.py` forms its inverse as `inv(C + 1e-7 I)`, an absolute
jitter, and at larger scales that perturbs the objective for reasons unrelated to
this fix. That is the secondary point in #31 and is deliberately **not** changed
here, to keep this diff reviewable.

## Test status

`39 passed, 5 failed`. The 5 failures are all in `tests/test_glm.py`
(`TypeError: hstack requires ndarray or scalar arguments, got <class 'list'>`),
reproduce identically on unmodified `master`, and look like the jax
incompatibility from #30. The existing `test_asd.py` and `test_ald.py` recovery
tests pass with this change.

Run on `rfest` at this branch, `jax` 0.11.0, numpy 2.x, Python 3.12, macOS arm64.

## Scope, and why #31 should stay open

This deliberately does **not** use a closing keyword for #31. Merging this leaves
two things from that issue unaddressed:

- the absolute `1e-7` jitter in `priors.py`, which is a separate numerical
  change across four kernels and deserves its own discussion;
- the note that ASD and ALD are baselines against the spline methods in the
  RFEst paper's simulation figures, which is a question about those results
  rather than about this code.

Happy to follow up with a second PR for the jitter if you want it.
