### PR TITLE
Scale the prior covariance jitter to the prior, and return C with its own inverse

### DIFF
--- a/rfest/EvidenceOpt/_fasd.py
+++ b/rfest/EvidenceOpt/_fasd.py
@@ -6,6 +6,8 @@ try:
 except ImportError:
     from jax.experimental import optimizers
 
+from rfest.priors import JITTER
+
 config.update("jax_enable_x64", True)
 
 __all__ = ["fASD"]
@@ -296,7 +298,12 @@ def asdf_cov(delta, ncoeff, freq, ext=1.25):
     const = (2 * np.pi / ncoeff_ext) ** 2
     freq *= const
     C_prior = np.sqrt(2 * np.pi) * np.exp(-0.5 * delta * freq**2)
-    C_prior_inv = 1 / (C_prior + 1e-7)
+
+    # Floored relative to the largest prior variance, then inverted exactly, so
+    # that C_prior and C_prior_inv are each other's inverse. See `_dense_prior`
+    # in rfest/priors.py for why that matters to the evidence.
+    C_prior = np.maximum(C_prior, JITTER * np.max(C_prior))
+    C_prior_inv = 1 / C_prior
 
     return C_prior, C_prior_inv
 

--- a/rfest/priors.py
+++ b/rfest/priors.py
@@ -3,6 +3,53 @@ import numpy as np
 
 __all__ = ["ridge_kernel", "sparsity_kernel", "smoothness_kernel", "locality_kernel", "realfftbasis"]
 
+# Jitter applied to a prior covariance before inverting it, as a fraction of the
+# largest prior variance. Relative rather than absolute: the prior covariance
+# carries the units of the RF, so a fixed jitter regularizes an arbitrary
+# amount -- nothing at all for a prior with large variances, and everything for
+# one with small variances.
+JITTER = 1e-7
+
+
+def _jitter(variances):
+    """`JITTER`, scaled to a prior with the given variances."""
+
+    scale = jnp.max(variances)
+
+    # `scale` is 0 only for a prior that has collapsed everywhere, which has no
+    # scale to be relative to; fall back to an absolute jitter there.
+    return JITTER * jnp.where(scale > 0, scale, 1.)
+
+
+def _diagonal_prior(variances, ncoeff):
+    """Jittered (C, C_inv) for a diagonal prior covariance.
+
+    Inverting elementwise is exact for a diagonal matrix, so the jitter only
+    has to keep the variances away from zero and is applied as a floor rather
+    than added throughout: well scaled variances are left untouched.
+    """
+
+    variances = jnp.broadcast_to(variances, (ncoeff,))
+    variances = jnp.maximum(variances, _jitter(variances))
+
+    return jnp.diag(variances), jnp.diag(1 / variances)
+
+
+def _dense_prior(C):
+    """Jittered (C, C_inv) for a dense prior covariance.
+
+    The jittered C is returned rather than kept private to this function,
+    so that C and C_inv are each other's inverse. The evidence uses both, and
+    `log|C Lambda^-1|` relies on the cancellation between them to stay well
+    conditioned when C is not -- pairing an unjittered C with a jittered
+    C_inv costs over 100 nats for the SE kernel at moderate smoothness, where
+    cond(C) exceeds 1e18 at only 20 coefficients.
+    """
+
+    C = C + jnp.eye(C.shape[0]) * _jitter(jnp.diag(C))
+
+    return C, jnp.linalg.inv(C)
+
 
 def ridge_kernel(params, ncoeff):
     """
@@ -10,10 +57,8 @@ def ridge_kernel(params, ncoeff):
     """
 
     theta = jnp.abs(params[0])
-    C = jnp.eye(ncoeff) * theta
-    C_inv = jnp.linalg.inv(C + jnp.eye(ncoeff) * 1e-07)
 
-    return C, C_inv
+    return _diagonal_prior(theta, ncoeff)
 
 
 def sparsity_kernel(params, ncoeff):
@@ -25,10 +70,8 @@ def sparsity_kernel(params, ncoeff):
     """
 
     theta = jnp.abs(params)
-    C = jnp.eye(ncoeff) * theta
-    C_inv = jnp.linalg.inv(C + jnp.eye(ncoeff) * 1e-07)
 
-    return C, C_inv
+    return _diagonal_prior(theta, ncoeff)
 
 
 def smoothness_kernel(params, ncoeff):
@@ -43,9 +86,8 @@ def smoothness_kernel(params, ncoeff):
     grid = jnp.arange(ncoeff)
     square_distance = (grid - grid.reshape(-1, 1)) ** 2  # pairwise squared distance
     C = jnp.exp(-.5 * square_distance / delta ** 2)
-    C_inv = jnp.linalg.inv(C + jnp.eye(ncoeff) * 1e-07)
 
-    return C, C_inv
+    return _dense_prior(C)
 
 
 def locality_kernel(params, ncoeff):
@@ -71,9 +113,8 @@ def locality_kernel(params, ncoeff):
     Cf = B.T @ jnp.diag(jnp.exp(-0.5 * (jnp.abs(tauf * freq) - nuf) ** 2)) @ B
 
     C = CxSqrt @ Cf @ CxSqrt
-    C_inv = jnp.linalg.inv(C + jnp.eye(ncoeff) * 1e-07)
 
-    return C, C_inv
+    return _dense_prior(C)
 
 
 def realfftbasis(nx):

--- a/tests/test_ald.py
+++ b/tests/test_ald.py
@@ -5,10 +5,13 @@ from rfest.utils import uvec
 
 
 def _fit_w_ald(X, y, dims):
+    # nus is the centre of the locality window in coefficient index, so it has
+    # to fall on the axis it belongs to: placing it off the end leaves every
+    # prior variance at ~1e-37 and the prior carries no locality information.
     sigma0 = [1.3]
     rho0 = [0.8]
-    params_t0 = [3., 20., 3., 20.9]  # taus, nus, tauf, nuf
-    params_y0 = [3., 20., 3., 20.9]
+    params_t0 = [3., (dims[0] - 1) / 2, 1., 0.]  # taus, nus, tauf, nuf
+    params_y0 = [3., (dims[1] - 1) / 2, 1., 0.]
     p0 = sigma0 + rho0 + params_t0 + params_y0
     model = ALD(X, y, dims=dims)
     model.fit(p0=p0, num_iters=30, verbose=0)

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from rfest import ASD, Ridge
+from rfest import ALD, ASD, Ridge
 
 
 def _exact_negative_log_evidence(X, y, C, sigma):
@@ -38,13 +38,11 @@ def _assert_matches_exact(model, params, X, y, sigma):
 
 
 def test_asd_negative_log_evidence_matches_gaussian_marginal():
-    # The smoothness scale is held small enough that the prior covariance stays
-    # well conditioned. `priors.py` forms its inverse as `inv(C + 1e-7 I)`, an
-    # absolute jitter, so at larger scales the objective departs from the exact
-    # evidence for a reason unrelated to the term under test here.
+    # cond(C) reaches 5e9 by a smoothness of 3 and 1e17 by 8, so the grid also
+    # covers the regime where the prior covariance is numerically singular.
     X, y, sigma = _smooth_rf_data()
     model = ASD(X, y, dims=[X.shape[1]])
-    for delta in [1., 1.5]:
+    for delta in [1., 1.5, 3., 8., 20.]:
         _assert_matches_exact(model, [sigma, 1., delta], X, y, sigma)
 
 
@@ -53,3 +51,23 @@ def test_ridge_negative_log_evidence_matches_gaussian_marginal():
     model = Ridge(X, y, dims=[X.shape[1]])
     for theta in [0.5, 2.]:
         _assert_matches_exact(model, [sigma, 1., theta], X, y, sigma)
+
+
+def test_ald_negative_log_evidence_matches_gaussian_marginal():
+    X, y, sigma = _smooth_rf_data()
+    model = ALD(X, y, dims=[X.shape[1]])
+    for params in ([sigma, 1., 2., 4., 1., 1.], [sigma, 1., 1., 4., 3., 1.]):
+        _assert_matches_exact(model, params, X, y, sigma)
+
+
+def test_negative_log_evidence_is_consistent_across_prior_scales():
+    """The prior scale rho must not change how accurately the evidence is computed.
+
+    A jitter that is absolute rather than relative to the prior variances
+    regularizes a differing amount at each scale, which shows up here as an
+    error that grows as rho shrinks.
+    """
+    X, y, sigma = _smooth_rf_data()
+    model = ASD(X, y, dims=[X.shape[1]])
+    for rho in [1e-4, 1e-2, 1., 1e2, 1e4]:
+        _assert_matches_exact(model, [sigma, rho, 3.], X, y, sigma)

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -1,0 +1,68 @@
+import numpy as np
+import pytest
+
+from rfest.priors import (
+    locality_kernel,
+    ridge_kernel,
+    smoothness_kernel,
+    sparsity_kernel,
+)
+
+NCOEFF = 20
+
+# Hyperparameters chosen to make each prior covariance badly conditioned, which
+# is the ordinary case: cond(C) for the SE kernel passes 1e12 at a smoothness
+# of 3 bins over 20 coefficients.
+KERNELS = {
+    "ridge": (ridge_kernel, [1.]),
+    "sparsity": (sparsity_kernel, np.linspace(.1, 1., NCOEFF)),
+    "smoothness": (smoothness_kernel, [8.]),
+    "locality": (locality_kernel, [2., NCOEFF / 2, 2., 1.]),
+}
+
+
+@pytest.mark.parametrize("name", list(KERNELS))
+def test_kernel_returns_a_matched_pair(name):
+    """C and C_inv must be each other's inverse, not each other's approximation.
+
+    Regularizing C_inv while returning C unregularized leaves the two describing
+    different priors. The evidence uses both, and `log|C Lambda^-1|` stays well
+    conditioned only through the cancellation between them.
+    """
+    kernel, params = KERNELS[name]
+    C, C_inv = (np.asarray(a) for a in kernel(params, NCOEFF))
+
+    assert np.allclose(C @ C_inv, np.eye(NCOEFF), atol=1e-6)
+
+
+@pytest.mark.parametrize("name", ["ridge", "sparsity"])
+@pytest.mark.parametrize("scale", [1e-6, 1e-3, 1., 1e3, 1e6])
+def test_variance_kernel_is_scale_invariant(name, scale):
+    """Scaling the prior variances must scale the prior precision inversely.
+
+    An absolute jitter breaks this: it is negligible against a prior with large
+    variances and dominant against one with small variances, so the same prior
+    expressed in different units gets regularized by different amounts.
+    """
+    kernel, params = KERNELS[name]
+    _, C_inv = kernel(params, NCOEFF)
+    _, C_inv_scaled = kernel(np.asarray(params) * scale, NCOEFF)
+
+    assert np.allclose(np.asarray(C_inv_scaled) * scale, np.asarray(C_inv), rtol=1e-6)
+
+
+@pytest.mark.parametrize("name", ["ridge", "sparsity"])
+def test_variance_kernel_survives_a_collapsed_variance(name):
+    """A prior variance driven to zero must not take the precision to infinity.
+
+    ARD prunes coefficients by driving their variance down, so this is reached
+    in ordinary use rather than only by a degenerate call.
+    """
+    kernel, params = KERNELS[name]
+    params = np.asarray(params, dtype=float) * np.ones(NCOEFF)
+    params[0] = 0.
+
+    C, C_inv = (np.asarray(a) for a in kernel(params, NCOEFF))
+
+    assert np.all(np.isfinite(C_inv))
+    assert np.allclose(C @ C_inv, np.eye(NCOEFF), atol=1e-6)


### PR DESCRIPTION
Fixes the secondary point in #31.

## The change

Every kernel in `priors.py` regularized its prior covariance the same way, and
returned the **unregularized** `C` alongside the regularized inverse:

```python
C_inv = jnp.linalg.inv(C + jnp.eye(ncoeff) * 1e-07)
return C, C_inv
```

Two separate problems there.

**The jitter is absolute.** The prior covariance carries the units of the RF, so
a fixed `1e-7` regularizes an arbitrary amount: nothing at all for a prior with
large variances, and everything for one with small variances. `ALD` at the
hyperparameters in `tests/test_ald.py` has prior variances of `1e-37`, so
`inv(C + 1e-7 I)` there is `1e7 I` — the locality prior is discarded and
replaced by ridge, silently.

**`C` and `C_inv` are not each other's inverse.** The evidence uses both, in
`log|C Lambda^-1|`, and that determinant stays well conditioned only through the
cancellation between them: `log|C (X'X/sigma^2 + C^-1)| == log|I + C X'X/sigma^2|`
exactly, and the right-hand side is well conditioned however singular `C` is.
Pair an unregularized `C` with a regularized `C^-1` and the cancellation fails.

So the jitter is now relative to the largest prior variance, and the regularized
`C` is returned with its own exact inverse. Diagonal priors (`ridge_kernel`,
`sparsity_kernel`) get the jitter as a floor and are inverted elementwise, which
is exact; dense ones (`smoothness_kernel`, `locality_kernel`) get it added to
the diagonal. `asdf_cov` in `_fasd.py` had the same `1 / (C_prior + 1e-7)` and
is fixed the same way.

The jitter magnitude is unchanged at `1e-7` and is now the named constant
`JITTER`.

## Numbers

`negative_log_evidence` against `log N(y; 0, sigma^2 I + X C X')` for `ASD` on a
20-tap smooth RF, `C` being the exact SE kernel at each smoothness:

| delta | cond(C) | exact | on master | this PR |
|---|---|---|---|---|
| 1 | 6.2e1 | 425.184 | -0.000 | 0.000 |
| 2 | 1.5e7 | 402.780 | -0.157 | 0.000 |
| 3 | 7.3e12 | 393.215 | -13.828 | 0.000 |
| 4 | 1.3e17 | 389.539 | -38.434 | 0.000 |
| 5 | 1.9e18 | 393.886 | -57.406 | -0.001 |
| 8 | 6.3e18 | 486.527 | -90.795 | -0.013 |
| 13 | 1.1e18 | 708.045 | -114.516 | -0.060 |
| 21 | 5.4e18 | 1125.919 | -130.453 | -0.105 |
| 34 | 2.3e19 | 1757.619 | -142.953 | -0.272 |

The remaining error is the jitter itself perturbing the prior, and it only
becomes visible at a smoothness larger than the RF. The argmin moves from
`delta = 5` to `delta = 4`, which is where the exact evidence peaks.

`ALD` recovery on `tests/test_ald.py`'s data improves from `mse = 2.5e-3` to
`9.8e-4` on the Poisson case once the locality prior is no longer being
replaced by ridge.

## Test changes

- `tests/test_priors.py`, new: each kernel returns a `(C, C_inv)` pair that are
  actual inverses; the two variance-parameterized kernels are invariant to the
  scale of those variances; a variance driven to zero does not produce an
  infinite precision. 8 of these 16 fail on master.
- `tests/test_evidence.py`: the `ASD` grid now runs to a smoothness of 20. It
  stopped at 1.5 with a comment saying why — that comment is what this PR is
  about, so it is gone. Adds `ALD`, and a check that the evidence is computed
  just as accurately at prior scales `rho` from `1e-4` to `1e4`. 3 of the 4
  tests in the file fail on master.
- `tests/test_ald.py`: its `p0` puts `nus`, the centre of the locality window in
  coefficient index, at 20 on axes of length 7 and 8. That leaves every prior
  variance at `1e-37`, and the test only passed because the absolute jitter
  turned the prior into ridge. `nus` now sits on the axis it belongs to. The
  test passes both with and without the rest of this PR, and recovers the RF
  better than before in both.

## Test status

`57 passed, 5 failed`. The 5 are `tests/test_glm.py`
(`TypeError: hstack requires ndarray or scalar arguments, got <class 'list'>`),
reproduce on unmodified master, and are the jax incompatibility in #30.

## Scope

This covers the secondary point of #31. Deliberately no closing keyword:
`_sard.py` still carries the `t2` defect that #32 fixed in `_base.py` and
`_fasd.py`, which is that issue's primary point, so #31 stays open until the
follow-up PR for `sARD` lands.
