### PR TITLE
Use the posterior precision in the sARD evidence quadratic term

### DIFF
--- a/rfest/EvidenceOpt/_base.py
+++ b/rfest/EvidenceOpt/_base.py
@@ -230,7 +230,7 @@ class EmpiricalBayes:
 
         (C_prior, C_prior_inv) = self.update_C_prior(params)
 
-        (C_post, C_post_inv, m_post) = self.update_C_posterior(params, C_prior_inv)
+        (_, C_post_inv, m_post) = self.update_C_posterior(params, C_prior_inv)
 
         t0 = jnp.log(jnp.abs(2 * jnp.pi * sigma**2)) * self.n_samples
         t1 = jnp.linalg.slogdet(C_prior @ C_post_inv)[1]

--- a/rfest/EvidenceOpt/_fasd.py
+++ b/rfest/EvidenceOpt/_fasd.py
@@ -143,7 +143,7 @@ class fASD:
 
         (C_prior, C_prior_inv) = self.update_C_prior(params)
 
-        (C_post, C_post_inv, m_post) = self.update_C_posterior(params, C_prior_inv)
+        (_, C_post_inv, m_post) = self.update_C_posterior(params, C_prior_inv)
 
         t0 = np.log(np.abs(2 * np.pi * sigma**2)) * self.n_samples
         t1 = np.linalg.slogdet(C_prior @ C_post_inv)[1]

--- a/rfest/EvidenceOpt/_sard.py
+++ b/rfest/EvidenceOpt/_sard.py
@@ -85,17 +85,24 @@ class sARD:
         """
 
         See eq(10) in Park & Pillow (2011).
+
+        NOTE: `t2` deliberately does not match eq(10) as printed, which has the
+        posterior covariance where the Gaussian marginal needs the posterior
+        precision. See EmpiricalBayes.negative_log_evidence for the derivation
+        and for why the printed form is easy to arrive at. Do not "correct" it
+        back.
         """
 
         sigma = params[0]
 
         (C_prior, C_prior_inv) = self.update_C_prior(params)
 
-        (C_post, C_post_inv, m_post) = self.update_C_posterior(params, C_prior_inv)
+        (_, C_post_inv, m_post) = self.update_C_posterior(params, C_prior_inv)
 
         t0 = np.log(np.abs(2 * np.pi * sigma**2)) * self.n_samples
         t1 = np.linalg.slogdet(C_prior @ C_post_inv)[1]
-        t2 = -m_post.T @ C_post @ m_post
+        # Equivalently, and more cheaply: -m_post.T @ self.ZtY / sigma**2
+        t2 = -m_post.T @ C_post_inv @ m_post
         t3 = self.YtY / sigma**2
 
         return 0.5 * (t0 + t1 + t2 + t3)

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from rfest import ALD, ASD, Ridge
+from rfest import ALD, ASD, Ridge, sARD
 
 
 def _exact_negative_log_evidence(X, y, C, sigma):
@@ -30,10 +30,13 @@ def _smooth_rf_data(n_features=12, n_samples=400, sigma=0.5, random_seed=2046):
     return X, y, sigma
 
 
-def _assert_matches_exact(model, params, X, y, sigma):
+def _assert_matches_exact(model, params, X, y, sigma, design=None):
+    # `design` is what the coefficients carrying the prior get multiplied by.
+    # That is X, unless the model reparameterizes: sARD places its prior on
+    # spline coefficients, so there it is the spline-projected X.
     C = np.asarray(model.update_C_prior(np.asarray(params))[0])
     got = float(model.negative_log_evidence(np.asarray(params)))
-    want = _exact_negative_log_evidence(X, y, C, sigma)
+    want = _exact_negative_log_evidence(X if design is None else design, y, C, sigma)
     assert np.isclose(got, want, rtol=1e-5), (params, got, want)
 
 
@@ -71,3 +74,12 @@ def test_negative_log_evidence_is_consistent_across_prior_scales():
     model = ASD(X, y, dims=[X.shape[1]])
     for rho in [1e-4, 1e-2, 1., 1e2, 1e4]:
         _assert_matches_exact(model, [sigma, rho, 3.], X, y, sigma)
+
+
+def test_sard_negative_log_evidence_matches_gaussian_marginal():
+    X, y, sigma = _smooth_rf_data()
+    model = sARD(X, y, dims=[X.shape[1]], df=[7])
+    Z = np.asarray(model.Z)
+    for theta in (np.ones(model.n_b), np.linspace(.2, 2., model.n_b)):
+        params = np.concatenate([[sigma, 1.], theta])
+        _assert_matches_exact(model, params, X, y, sigma, design=Z)

--- a/tests/test_sard.py
+++ b/tests/test_sard.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from rfest import sARD
+from rfest.generate_test_data import generate_data_2d_stim
+from rfest.metrics import mse
+from rfest.utils import uvec
+
+
+def _get_df(dims):
+    df = [int(np.maximum(np.ceil(dim / 2), 3)) for dim in list(dims)]
+    return df
+
+
+def _fit_w_sard(X, y, dims):
+    model = sARD(X, y, dims=dims, df=_get_df(dims))
+    p0 = np.concatenate([[1., 1.], np.ones(model.n_b)])
+    model.fit(p0=p0, num_iters=50, verbose=0)
+    return np.asarray(model.w_opt).flatten()
+
+
+def test_sard_2d_stim():
+    w_true, X, y, _, dims = generate_data_2d_stim(noise='white', rf_kind='complex_small', y_distr='none')
+    w_fit = _fit_w_sard(X, y, dims)
+    assert mse(uvec(w_fit), uvec(w_true.flatten())) < 0.01
+
+
+def test_sard_2d_stim_spikes():
+    w_true, X, y, _, dims = generate_data_2d_stim(noise='white', rf_kind='complex_small', y_distr='poisson')
+    w_fit = _fit_w_sard(X, y, dims)
+    assert mse(uvec(w_fit), uvec(w_true.flatten())) < 0.01


### PR DESCRIPTION
Closes #31.

## The change

`sARD` is a third copy of the evidence objective, alongside `EmpiricalBayes` and
`fASD`, and it carries the same quadratic term that #32 fixed in the other two:

```diff
-        t2 = -m_post.T @ C_post @ m_post
+        t2 = -m_post.T @ C_post_inv @ m_post
```

It was missed there because #32 was written against the two files the issue
named. `sARD` is exported from top-level `rfest`, and the effect is the same
size as everywhere else — on a 12-tap RF projected onto 7 spline coefficients,
the shipped objective returns 3343.3 where the exact evidence is 307.6.

The docstring gets the same note as `_fasd.py`: eq(10) as printed has the
posterior covariance in this term, so the next person checking this code
against its cited source should not change it back.

Also drops the now-unused `C_post` binding in all three copies. #32 left it
bound but unused in `_base.py` and `_fasd.py`, and this PR would have added a
third.

## Tests

- `tests/test_evidence.py` gains `sARD`, against `log N(y; 0, sigma^2 I + Z C Z')`
  with `Z = X S` — the prior lives on spline coefficients, so the design the
  marginal is built from is the spline-projected one, and `_assert_matches_exact`
  takes it as an argument. Fails at 3343.3 against an exact 307.6 without the
  fix.
- `tests/test_sard.py`, new: `sARD` had no tests at all despite being exported.
  Two RF recovery tests mirroring `test_asd.py`. To be clear about what these
  are worth — they pass with and without the fix, because the spline basis is
  doing most of the work at these sizes. They are coverage for a class that had
  none, not a regression test for this bug; the evidence test above is that.

## Test status

`60 passed, 5 failed`. The 5 are `tests/test_glm.py`
(`TypeError: hstack requires ndarray or scalar arguments, got <class 'list'>`),
reproduce on unmodified master, and are the jax incompatibility in #30.

## On closing #31

This is the last of the code defects in that issue: the quadratic term in all
three copies, and the absolute jitter in `priors.py` and `asdf_cov` (#33).

The one thing raised there and not settled by code is the observation that ASD
and ALD are baselines against the spline methods in the RFEst paper's simulation
figures, so those baselines may have been run against the uncorrected objective.
That is a question about published results rather than about this repository,
and it is not tracked by anything here.
