### PR TITLE
Replace np.product, removed in numpy 2, so ARD runs again

### DIFF
--- a/rfest/EvidenceOpt/_ard.py
+++ b/rfest/EvidenceOpt/_ard.py
@@ -1,3 +1,5 @@
+import math
+
 import jax.numpy as np
 from sklearn.metrics import mean_squared_error
 
@@ -27,7 +29,7 @@ class ARD(EmpiricalBayes):
         """
         rho = params[1]
         theta = params[2:]
-        C, C_inv = sparsity_kernel(theta, np.product(self.dims))
+        C, C_inv = sparsity_kernel(theta, math.prod(self.dims))
         C *= rho
         C_inv /= rho
 

--- a/tests/test_ard.py
+++ b/tests/test_ard.py
@@ -1,0 +1,41 @@
+import numpy as np
+
+from rfest import ARD, ARDFixedPoint
+from rfest.generate_test_data import generate_data_2d_stim
+from rfest.metrics import mse
+from rfest.utils import uvec
+
+
+def _fit_w_ard(X, y, dims):
+    model = ARD(X, y, dims=list(dims))
+    # ARD gives every coefficient its own hyperparameter, so p0 carries one
+    # theta per pixel on top of sigma and rho.
+    p0 = np.concatenate([[1., 1.], np.ones(X.shape[1])])
+    model.fit(p0=p0, num_iters=100, verbose=0)
+    return np.asarray(model.optimized_C_post @ X.T @ y / model.optimized_params[0] ** 2)
+
+
+def _fit_w_ard_fixed_point(X, y, dims):
+    model = ARDFixedPoint(X, y, dims=list(dims))
+    # Here the per-coefficient hyperparameter is a precision, not a variance.
+    p0 = np.concatenate([[1.], np.ones(X.shape[1])])
+    model.fit(p0=p0, num_iters=100, verbose=False)
+    return np.asarray(model.w_opt).flatten()
+
+
+def test_ard_2d_stim():
+    w_true, X, y, _, dims = generate_data_2d_stim(noise='white', rf_kind='complex_small', y_distr='none')
+    w_fit = _fit_w_ard(X, y, dims)
+    assert mse(uvec(w_fit), uvec(w_true.flatten())) < 0.01
+
+
+def test_ard_2d_stim_spikes():
+    w_true, X, y, _, dims = generate_data_2d_stim(noise='white', rf_kind='complex_small', y_distr='poisson')
+    w_fit = _fit_w_ard(X, y, dims)
+    assert mse(uvec(w_fit), uvec(w_true.flatten())) < 0.01
+
+
+def test_ard_fixed_point_2d_stim():
+    w_true, X, y, _, dims = generate_data_2d_stim(noise='white', rf_kind='complex_small', y_distr='none')
+    w_fit = _fit_w_ard_fixed_point(X, y, dims)
+    assert mse(uvec(w_fit), uvec(w_true.flatten())) < 0.01

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from rfest import ALD, ASD, Ridge, sARD
+from rfest import ALD, ARD, ASD, Ridge, sARD
 
 
 def _exact_negative_log_evidence(X, y, C, sigma):
@@ -83,3 +83,10 @@ def test_sard_negative_log_evidence_matches_gaussian_marginal():
     for theta in (np.ones(model.n_b), np.linspace(.2, 2., model.n_b)):
         params = np.concatenate([[sigma, 1.], theta])
         _assert_matches_exact(model, params, X, y, sigma, design=Z)
+
+
+def test_ard_negative_log_evidence_matches_gaussian_marginal():
+    X, y, sigma = _smooth_rf_data()
+    model = ARD(X, y, dims=[X.shape[1]])
+    for theta in (np.ones(X.shape[1]), np.linspace(.2, 2., X.shape[1])):
+        _assert_matches_exact(model, np.concatenate([[sigma, 1.], theta]), X, y, sigma)


### PR DESCRIPTION
`ARD.update_C_prior` asked for the number of coefficients with
`np.product(self.dims)`. numpy removed that alias in 2.0 and `jax.numpy` went
with it, so every call raised

```
AttributeError: module 'jax.numpy' has no attribute 'product'
```

`ARD` was not producing worse answers, it was producing none. It is exported
from top level and is the first line of the `EvidenceOpt` docs in the README.

`math.prod` rather than `np.prod`: the value is the `ncoeff` argument to
`sparsity_kernel`, which uses it as a shape, so it has to be a Python int and
not something that could arrive traced.

## Why nobody noticed

`ARD` had no tests. `test_asd.py` and `test_ald.py` exist, `test_ard.py` did
not, so the only thing standing between a removed numpy alias and a broken
estimator was somebody happening to run it.

- `tests/test_ard.py`, new: RF recovery for `ARD` and for `ARDFixedPoint`. The
  two `ARD` tests fail on master with the `AttributeError` above.
- `tests/test_evidence.py` gains `ARD`, against
  `log N(y; 0, sigma^2 I + X C X')`. It matches to 4 decimal places
  (`1112.2579` both ways). This is the first time that objective could be
  evaluated at all, and it confirms that #32 and #33 carry over to the ARD
  path, which until now was assumed rather than checked.

`ARDFixedPoint` is a separate implementation that never touched `np.product`
and was never broken. Its test is there because the class had no coverage
either, not because this changes anything for it.

## Test status

`69 passed`, nothing failing.
