### PR TITLE
Take the five action bumps as one change, and group future ones

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,17 @@
-# Actions are pinned to commit SHAs, which is the safer way to depend on
-# third-party code but only works if something bumps them. Nothing did: the
-# publish action sat on v1.4.2 for four years, and by the end it predated the
-# authentication method the workflow needed.
+# The publish action is pinned to a commit SHA and the rest to major tags;
+# either way something has to bump them, and nothing did. That action sat on
+# v1.4.2 for four years, until it predated the authentication method the
+# workflow needed.
+#
+# Grouped into one pull request. Ungrouped, a month's worth of action releases
+# arrives as five separate PRs that each want their own review and CI run.
 version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: monthly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -28,9 +28,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: '3.x'
     - name: Build release distributions
@@ -39,7 +39,7 @@ jobs:
         python -m pip install build
         python -m build
     - name: Upload distributions
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: release-dists
         path: dist/
@@ -63,7 +63,7 @@ jobs:
 
     steps:
     - name: Retrieve release distributions
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: release-dists
         path: dist/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: ['3.11', '3.12', '3.13']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
     # No uv.lock is committed, so each run resolves dependencies afresh and a
@@ -34,9 +34,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
     # `ruff check` is deliberately not run yet. The tree has 243 lint findings,


### PR DESCRIPTION
Dependabot opened #41 through #45, one per action. This is the same five bumps
as a single change, plus the config key that stops it happening again.

Supersedes #41, #42, #43, #44 and #45, which need closing by hand — closing
keywords only act on issues, not on other pull requests.

## The bumps

| action | from | to | exercised by CI |
|---|---|---|---|
| actions/checkout | v4 | v7 | yes |
| astral-sh/setup-uv | v5 | v7 | yes |
| actions/setup-python | v5 | v7 | no |
| actions/upload-artifact | v4 | v7 | no |
| actions/download-artifact | v4 | v8 | no |

Every major here is a node 24 runtime upgrade. The "breaking" label on them is
about minimum runner version, which constrains self-hosted runners; both
workflows are on `ubuntu-latest`.

The pair worth checking rather than waving through is upload/download, because
dependabot bumped them to *different* majors and they have to agree. They do:
download v8's release notes say it skips unzipping non-zipped downloads
specifically "to support direct uploads in `actions/upload-artifact`", which is
upload v7's new `archive: false`. v7 and v8 are the intended pair. Neither
change touches the default path — this repo uploads a `dist/` directory, which
is still zipped, and does not set `archive` or `skip-decompress`. v8 also
promotes a download hash mismatch from a warning to an error, which is a
behaviour change we want.

**The last three rows are not covered by CI**, because they only appear in
`python-publish.yml`, which runs on `release: published`. A green run on this PR
says nothing about them; the first real exercise is publishing 2.2.0. That is
worth knowing before the release rather than during it.

## The grouping

```yaml
    groups:
      actions:
        patterns:
          - "*"
```

Ungrouped, a month of action releases is five PRs that each want a review and a
CI run, for what is one decision. Grouped, it is one.

Also corrects the comment in that file, which claimed the actions are pinned to
commit SHAs. Only `pypa/gh-action-pypi-publish` is; the rest track major tags,
which is the usual line for first-party `actions/*`. `astral-sh/setup-uv` is
third party and arguably belongs on a SHA, but that is a separate hardening
decision rather than something to fold into a version bump.
